### PR TITLE
Feature/s3

### DIFF
--- a/frontend/src/api/files.js
+++ b/frontend/src/api/files.js
@@ -24,11 +24,19 @@ export const fileApi = {
   },
 
   uploadToS3: async (uploadUrl, file) => {
+    const isLocal = uploadUrl.startsWith('http://localhost');
+
+    if (isLocal) {
+      return client.put(uploadUrl, file, {
+        headers: { 'Content-Type': file.type },
+        baseURL: ''  // Important: prevents the client's baseURL from being added
+      });
+    }
+
+    // S3 presigned URL
     // We use raw axios here because we don't want the default client headers/baseUrl
     return axios.put(uploadUrl, file, {
-      headers: {
-        'Content-Type': file.type
-      }
+      headers: { 'Content-Type': file.type }
     });
   },
 

--- a/frontend/src/api/files.js
+++ b/frontend/src/api/files.js
@@ -24,7 +24,7 @@ export const fileApi = {
   },
 
   uploadToS3: async (uploadUrl, file) => {
-    const isLocal = uploadUrl.startsWith('http://localhost');
+    const isLocal = uploadUrl.startsWith('/api/files/local');
 
     if (isLocal) {
       return client.put(uploadUrl, file, {

--- a/frontend/src/components/dashboard/FileSection.jsx
+++ b/frontend/src/components/dashboard/FileSection.jsx
@@ -59,6 +59,7 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
   };
 
   const handleDownload = async (file) => {
+    setUploadError(null)
     try {
       const response = await fetch(file.downloadUrl, {
         credentials: 'include'
@@ -87,6 +88,7 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
   };
 
   const handlePreview = async (file) => {
+    setUploadError(null)
     try {
       const response = await fetch(file.downloadUrl, {
         credentials: 'include'

--- a/frontend/src/components/dashboard/FileSection.jsx
+++ b/frontend/src/components/dashboard/FileSection.jsx
@@ -6,13 +6,21 @@ import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { FileIcon, Upload, Download, Loader2, X, ZoomIn } from 'lucide-react';
 
 const IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
-const [previewBlobUrl, setPreviewBlobUrl] = useState(null);
 
 export function FileSection({ files: initialFiles = [], assignmentId, commentId }) {
   const [files, setFiles] = useState(initialFiles);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState(null);
   const [previewFile, setPreviewFile] = useState(null);
+  const [previewBlobUrl, setPreviewBlobUrl] = useState(null);
+
+  useEffect(() => {
+    return () => {
+      if (previewBlobUrl) {
+        URL.revokeObjectURL(previewBlobUrl);
+      }
+    };
+  }, [previewBlobUrl]);
 
   const handleUpload = async (e) => {
     const selectedFile = e.target.files[0];
@@ -58,13 +66,9 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
 
       if (!response.ok) {
         let errorMsg;
-        if (response.status === 403) {
-          errorMsg = 'Du har inte behörighet att ladda ner filen';
-        } else if (response.status === 404) {
-          errorMsg = 'Filen kunde inte hittas';
-        } else {
-          errorMsg = 'Nedladdningen misslyckades';
-        }
+        if (response.status === 403) errorMsg = 'Du har inte behörighet att ladda ner filen';
+        else if (response.status === 404) errorMsg = 'Filen kunde inte hittas';
+        else errorMsg = 'Nedladdningen misslyckades';
         setUploadError(errorMsg);
         return;
       }
@@ -90,24 +94,12 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
 
       if (!response.ok) {
         let errorMsg;
-        if (response.status === 403) {
-          errorMsg = 'Du har inte behörighet att se bilden';
-        } else if (response.status === 404) {
-          errorMsg = 'Bilden kunde inte hittas';
-        } else {
-          errorMsg = 'Kunde inte ladda bilden';
-        }
+        if (response.status === 403) errorMsg = 'Du har inte behörighet att se bilden';
+        else if (response.status === 404) errorMsg = 'Bilden kunde inte hittas';
+        else errorMsg = 'Kunde inte ladda bilden';
         setUploadError(errorMsg);
         return;
       }
-
-      useEffect(() => {
-        return () => {
-          if (previewBlobUrl) {
-            URL.revokeObjectURL(previewBlobUrl);
-          }
-        };
-      }, [previewBlobUrl]);
 
       const blob = await response.blob();
       const url = URL.createObjectURL(blob);
@@ -207,11 +199,11 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
           }
         }}
       >
-        <DialogContent className="max-w-[95vw] w-fit p-4 sm:p-6">
+        <DialogContent className="max-w-[90vw] w-[90vw] p-4">
           <img
             src={previewBlobUrl || previewFile?.downloadUrl}
             alt={previewFile?.fileName}
-            className="max-w-[90vw] max-h-[80vh] object-contain rounded"
+            className="w-full max-h-[80vh] object-contain rounded"
           />
           <p className="text-center text-sm text-muted-foreground mt-2">
             {previewFile?.fileName}

--- a/frontend/src/components/dashboard/FileSection.jsx
+++ b/frontend/src/components/dashboard/FileSection.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { fileApi } from '@/api/files';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -6,6 +6,7 @@ import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { FileIcon, Upload, Download, Loader2, X, ZoomIn } from 'lucide-react';
 
 const IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
+const [previewBlobUrl, setPreviewBlobUrl] = useState(null);
 
 export function FileSection({ files: initialFiles = [], assignmentId, commentId }) {
   const [files, setFiles] = useState(initialFiles);
@@ -100,6 +101,17 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
         return;
       }
 
+      useEffect(() => {
+        return () => {
+          if (previewBlobUrl) {
+            URL.revokeObjectURL(previewBlobUrl);
+          }
+        };
+      }, [previewBlobUrl]);
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      setPreviewBlobUrl(url);
       setPreviewFile(file);
     } catch (error) {
       console.error('Preview failed:', error);
@@ -185,10 +197,19 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
         </CardContent>
       </Card>
 
-      <Dialog open={!!previewFile} onOpenChange={() => setPreviewFile(null)}>
-        <DialogContent className="max-w-[95vw] w-fit p-4 sm:p-6 max-w-none!">
+      <Dialog
+        open={!!previewFile}
+        onOpenChange={() => {
+          setPreviewFile(null);
+          if (previewBlobUrl) {
+            URL.revokeObjectURL(previewBlobUrl);
+            setPreviewBlobUrl(null);
+          }
+        }}
+      >
+        <DialogContent className="max-w-[95vw] w-fit p-4 sm:p-6">
           <img
-            src={previewFile?.downloadUrl}
+            src={previewBlobUrl || previewFile?.downloadUrl}
             alt={previewFile?.fileName}
             className="max-w-[90vw] max-h-[80vh] object-contain rounded"
           />

--- a/frontend/src/components/dashboard/FileSection.jsx
+++ b/frontend/src/components/dashboard/FileSection.jsx
@@ -2,12 +2,16 @@ import { useState } from 'react';
 import { fileApi } from '@/api/files';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { FileIcon, Upload, Download, Loader2, X } from 'lucide-react';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { FileIcon, Upload, Download, Loader2, X, ZoomIn } from 'lucide-react';
+
+const IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
 
 export function FileSection({ files: initialFiles = [], assignmentId, commentId }) {
   const [files, setFiles] = useState(initialFiles);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState(null);
+  const [previewFile, setPreviewFile] = useState(null);
 
   const handleUpload = async (e) => {
     const selectedFile = e.target.files[0];
@@ -17,7 +21,6 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
       setIsUploading(true);
       setUploadError(null);
 
-      // 1. Get pre-signed URL
       const { uploadUrl, s3Key } = await fileApi.getUploadUrl(
         selectedFile.name,
         selectedFile.type,
@@ -25,10 +28,8 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
         commentId
       );
 
-      // 2. Upload to S3 (or local S3-mock)
       await fileApi.uploadToS3(uploadUrl, selectedFile);
 
-      // 3. Finalize in backend
       const savedFile = await fileApi.finalizeUpload(
         s3Key,
         selectedFile.name,
@@ -44,10 +45,28 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
       setUploadError('Uppladdningen misslyckades. Försök igen.');
     } finally {
       setIsUploading(false);
-      // Reset input
       e.target.value = '';
     }
   };
+
+  const handleDownload = async (file) => {
+    try {
+      const response = await fetch(file.downloadUrl, {
+        credentials: 'include'
+      });
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = file.fileName;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Download failed:', error);
+    }
+  };
+
+  const isImage = (file) => IMAGE_TYPES.includes(file.contentType);
 
   const formatFileSize = (bytes) => {
     if (!bytes || bytes <= 0) return '0 B';
@@ -58,70 +77,85 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
   };
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0">
-        <CardTitle>Bilagor ({files.length})</CardTitle>
-        <div className="relative">
-          <input
-            type="file"
-            id="file-upload"
-            className="hidden"
-            onChange={handleUpload}
-            disabled={isUploading}
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            asChild
-            disabled={isUploading}
-          >
-            <label htmlFor="file-upload" className="cursor-pointer">
-              {isUploading ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Upload className="mr-2 h-4 w-4" />
-              )}
-              Ladda upp
-            </label>
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {uploadError && (
-          <div className="text-sm text-destructive flex items-center justify-between bg-destructive/10 p-2 rounded">
-            {uploadError}
-            <Button variant="ghost" size="icon" className="h-4 w-4" onClick={() => setUploadError(null)}>
-              <X className="h-3 w-3" />
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle>Bilagor ({files.length})</CardTitle>
+          <div className="relative">
+            <input
+              type="file"
+              id="file-upload"
+              className="hidden"
+              onChange={handleUpload}
+              disabled={isUploading}
+            />
+            <Button variant="outline" size="sm" asChild disabled={isUploading}>
+              <label htmlFor="file-upload" className="cursor-pointer">
+                {isUploading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Upload className="mr-2 h-4 w-4" />
+                )}
+                Ladda upp
+              </label>
             </Button>
           </div>
-        )}
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {uploadError && (
+            <div className="text-sm text-destructive flex items-center justify-between bg-destructive/10 p-2 rounded">
+              {uploadError}
+              <Button variant="ghost" size="icon" className="h-4 w-4" onClick={() => setUploadError(null)}>
+                <X className="h-3 w-3" />
+              </Button>
+            </div>
+          )}
 
-        {files.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Inga bilagor uppladdade.</p>
-        ) : (
-          <div className="space-y-2">
-            {files.map((file) => (
-              <div
-                key={file.id}
-                className="flex items-center justify-between p-2 rounded-md border bg-muted/30"
-              >
-                <div className="flex items-center gap-3 overflow-hidden">
-                  <FileIcon className="h-4 w-4 text-blue-500 shrink-0" />
-                  <div className="flex flex-col overflow-hidden">
-                    <span className="text-sm font-medium truncate">{file.fileName}</span>
-                    <span className="text-xs text-muted-foreground">{formatFileSize(file.fileSize)}</span>
+          {files.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Inga bilagor uppladdade.</p>
+          ) : (
+            <div className="space-y-2">
+              {files.map((file) => (
+                <div
+                  key={file.id}
+                  className="flex items-center justify-between p-2 rounded-md border bg-muted/30"
+                >
+                  <div className="flex items-center gap-3 overflow-hidden">
+                    <FileIcon className="h-4 w-4 text-blue-500 shrink-0" />
+                    <div className="flex flex-col overflow-hidden">
+                      <span className="text-sm font-medium truncate">{file.fileName}</span>
+                      <span className="text-xs text-muted-foreground">{formatFileSize(file.fileSize)}</span>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    {isImage(file) && (
+                      <Button variant="ghost" size="icon" onClick={() => setPreviewFile(file)}>
+                        <ZoomIn className="h-4 w-4" />
+                      </Button>
+                    )}
+                    <Button variant="ghost" size="icon" onClick={() => handleDownload(file)}>
+                      <Download className="h-4 w-4" />
+                    </Button>
                   </div>
                 </div>
-                <Button variant="ghost" size="icon" asChild>
-                  <a href={file.downloadUrl} target="_blank" rel="noopener noreferrer">
-                    <Download className="h-4 w-4" />
-                  </a>
-                </Button>
-              </div>
-            ))}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={!!previewFile} onOpenChange={() => setPreviewFile(null)}>
+        <DialogContent className="max-w-[95vw] w-fit p-4 sm:p-6 max-w-none!">
+          <img
+            src={previewFile?.downloadUrl}
+            alt={previewFile?.fileName}
+            className="max-w-[90vw] max-h-[80vh] object-contain rounded"
+          />
+          <p className="text-center text-sm text-muted-foreground mt-2">
+            {previewFile?.fileName}
+          </p>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/frontend/src/components/dashboard/FileSection.jsx
+++ b/frontend/src/components/dashboard/FileSection.jsx
@@ -54,6 +54,20 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
       const response = await fetch(file.downloadUrl, {
         credentials: 'include'
       });
+
+      if (!response.ok) {
+        let errorMsg;
+        if (response.status === 403) {
+          errorMsg = 'Du har inte behörighet att ladda ner filen';
+        } else if (response.status === 404) {
+          errorMsg = 'Filen kunde inte hittas';
+        } else {
+          errorMsg = 'Nedladdningen misslyckades';
+        }
+        setUploadError(errorMsg);
+        return;
+      }
+
       const blob = await response.blob();
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -63,6 +77,33 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
       URL.revokeObjectURL(url);
     } catch (error) {
       console.error('Download failed:', error);
+      setUploadError('Kunde inte ladda ner filen. Försök igen.');
+    }
+  };
+
+  const handlePreview = async (file) => {
+    try {
+      const response = await fetch(file.downloadUrl, {
+        credentials: 'include'
+      });
+
+      if (!response.ok) {
+        let errorMsg;
+        if (response.status === 403) {
+          errorMsg = 'Du har inte behörighet att se bilden';
+        } else if (response.status === 404) {
+          errorMsg = 'Bilden kunde inte hittas';
+        } else {
+          errorMsg = 'Kunde inte ladda bilden';
+        }
+        setUploadError(errorMsg);
+        return;
+      }
+
+      setPreviewFile(file);
+    } catch (error) {
+      console.error('Preview failed:', error);
+      setUploadError('Kunde inte ladda bilden. Försök igen.');
     }
   };
 
@@ -129,7 +170,7 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
                   </div>
                   <div className="flex items-center gap-1">
                     {isImage(file) && (
-                      <Button variant="ghost" size="icon" onClick={() => setPreviewFile(file)}>
+                      <Button variant="ghost" size="icon" onClick={() => handlePreview(file)}>
                         <ZoomIn className="h-4 w-4" />
                       </Button>
                     )}

--- a/frontend/src/components/dashboard/FileSection.jsx
+++ b/frontend/src/components/dashboard/FileSection.jsx
@@ -152,7 +152,7 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
           {uploadError && (
             <div className="text-sm text-destructive flex items-center justify-between bg-destructive/10 p-2 rounded">
               {uploadError}
-              <Button variant="ghost" size="icon" className="h-4 w-4" onClick={() => setUploadError(null)}>
+              <Button variant="ghost" size="icon" className="h-4 w-4" aria-label="Stäng felmeddelande" onClick={() => setUploadError(null)}>
                 <X className="h-3 w-3" />
               </Button>
             </div>
@@ -176,11 +176,11 @@ export function FileSection({ files: initialFiles = [], assignmentId, commentId 
                   </div>
                   <div className="flex items-center gap-1">
                     {isImage(file) && (
-                      <Button variant="ghost" size="icon" onClick={() => handlePreview(file)}>
+                      <Button variant="ghost" size="icon" aria-label={`Förhandsvisa ${file.fileName}`} onClick={() => handlePreview(file)}>
                         <ZoomIn className="h-4 w-4" />
                       </Button>
                     )}
-                    <Button variant="ghost" size="icon" onClick={() => handleDownload(file)}>
+                    <Button variant="ghost" size="icon" aria-label={`Ladda ner ${file.fileName}`} onClick={() => handleDownload(file)}>
                       <Download className="h-4 w-4" />
                     </Button>
                   </div>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
             <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/config/S3Config.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/config/S3Config.java
@@ -1,9 +1,6 @@
 package org.example.projectbackendteammycodebasebringsalltheboys.config;
 
-import org.example.projectbackendteammycodebasebringsalltheboys.storage.S3StorageService;
-import org.example.projectbackendteammycodebasebringsalltheboys.storage.StorageService;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -47,11 +44,5 @@ public class S3Config {
         .credentialsProvider(
             StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
         .build();
-  }
-
-  @ConditionalOnMissingBean(StorageService.class)
-  @Bean
-  public StorageService storageService(S3Client s3Client, S3Presigner s3Presigner) {
-    return new S3StorageService(s3Client, s3Presigner, bucketName);
   }
 }

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/config/S3Config.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/config/S3Config.java
@@ -25,9 +25,6 @@ public class S3Config {
   @Value("${aws.s3.secret-key:dummy}")
   private String secretKey;
 
-  @Value("${aws.s3.bucket-name}")
-  private String bucketName;
-
   @Bean
   public S3Client s3Client() {
     return S3Client.builder()

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/config/StorageConfig.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/config/StorageConfig.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
@@ -23,6 +24,7 @@ public class StorageConfig {
   }
 
   @Bean
+  @Primary
   @ConditionalOnProperty(name = "storage.type", havingValue = "local", matchIfMissing = true)
   public StorageService localStorageService() {
     return new LocalStorageService();

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/config/StorageConfig.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/config/StorageConfig.java
@@ -26,7 +26,7 @@ public class StorageConfig {
   @Bean
   @Primary
   @ConditionalOnProperty(name = "storage.type", havingValue = "local", matchIfMissing = true)
-  public StorageService localStorageService() {
+  public LocalStorageService localStorageService() {
     return new LocalStorageService();
   }
 }

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileController.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileController.java
@@ -1,6 +1,7 @@
 package org.example.projectbackendteammycodebasebringsalltheboys.controller;
 
 import jakarta.validation.Valid;
+import java.io.InputStream;
 import java.security.Principal;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +19,11 @@ import org.example.projectbackendteammycodebasebringsalltheboys.exception.NotFou
 import org.example.projectbackendteammycodebasebringsalltheboys.exception.UnauthorizedException;
 import org.example.projectbackendteammycodebasebringsalltheboys.mapper.DtoMapper;
 import org.example.projectbackendteammycodebasebringsalltheboys.service.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @RestController
 @RequestMapping("/api/files")
@@ -42,6 +46,40 @@ public class FileController {
 
     return ResponseEntity.ok(
         new UploadResponse(generatedUpload.uploadUrl(), generatedUpload.s3Key()));
+  }
+
+  @GetMapping("/{id}/download")
+  public ResponseEntity<StreamingResponseBody> downloadFile(
+      @PathVariable UUID id, Principal principal) {
+
+    if (principal == null) {
+      return ResponseEntity.status(401).build();
+    }
+
+    User currentUser =
+        userService
+            .getUserByUsername(principal.getName())
+            .orElseThrow(() -> new UnauthorizedException("Current user not found"));
+
+    FileMetadata file =
+        fileService.getFileById(id).orElseThrow(() -> new NotFoundException("File not found"));
+
+    if (!canAccessFile(currentUser, file)) {
+      throw new ForbiddenException("You are not allowed to access this file");
+    }
+
+    StreamingResponseBody stream =
+        outputStream -> {
+          try (InputStream inputStream = fileService.downloadFile(file)) {
+            inputStream.transferTo(outputStream);
+          }
+        };
+
+    return ResponseEntity.ok()
+        .contentType(MediaType.parseMediaType(file.getContentType()))
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getFileName() + "\"")
+        .body(stream);
   }
 
   @PostMapping("/finalize")

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileController.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileController.java
@@ -2,6 +2,7 @@ package org.example.projectbackendteammycodebasebringsalltheboys.controller;
 
 import jakarta.validation.Valid;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import org.example.projectbackendteammycodebasebringsalltheboys.exception.NotFou
 import org.example.projectbackendteammycodebasebringsalltheboys.exception.UnauthorizedException;
 import org.example.projectbackendteammycodebasebringsalltheboys.mapper.DtoMapper;
 import org.example.projectbackendteammycodebasebringsalltheboys.service.*;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -68,6 +70,17 @@ public class FileController {
       throw new ForbiddenException("You are not allowed to access this file");
     }
 
+    String contentType = file.getContentType();
+    MediaType mediaType =
+        (contentType != null && !contentType.isBlank())
+            ? MediaType.parseMediaType(contentType)
+            : MediaType.APPLICATION_OCTET_STREAM;
+
+    ContentDisposition disposition =
+        ContentDisposition.attachment()
+            .filename(file.getFileName(), StandardCharsets.UTF_8)
+            .build();
+
     StreamingResponseBody stream =
         outputStream -> {
           try (InputStream inputStream = fileService.downloadFile(file)) {
@@ -76,9 +89,8 @@ public class FileController {
         };
 
     return ResponseEntity.ok()
-        .contentType(MediaType.parseMediaType(file.getContentType()))
-        .header(
-            HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getFileName() + "\"")
+        .contentType(mediaType)
+        .header(HttpHeaders.CONTENT_DISPOSITION, disposition.toString())
         .body(stream);
   }
 

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileController.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileController.java
@@ -75,7 +75,7 @@ public class FileController {
               .getCaseById(request.getAssignmentId())
               .orElseThrow(() -> new NotFoundException("Assignment not found"));
 
-      if (!authorizationService.canModifyAssignment(currentUser, assignment)) {
+      if (!authorizationService.canAccessCase(currentUser, assignment)) {
         throw new ForbiddenException("You are not allowed to attach files to this assignment");
       }
     }

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileController.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileController.java
@@ -185,20 +185,21 @@ public class FileController {
     // 3. Students can only access files uploaded by teachers/admins (not other students)
     if (isStudent(user)) {
       boolean isFromTeacherOrAdmin =
-              "ROLE_TEACHER".equals(file.getUploader().getRole().getName())
-                      || "ROLE_ADMIN".equals(file.getUploader().getRole().getName());
+          "ROLE_TEACHER".equals(file.getUploader().getRole().getName())
+              || "ROLE_ADMIN".equals(file.getUploader().getRole().getName());
 
       if (isFromTeacherOrAdmin) {
         // If file is attached to an assignment
         if (file.getAssignment() != null
-                && authorizationService.canAccessAssignmentDetails(user, file.getAssignment())) {
+            && authorizationService.canAccessAssignmentDetails(user, file.getAssignment())) {
           return true;
         }
 
         // If file is attached to a comment
         if (file.getComment() != null
-                && file.getComment().getAssignment() != null
-                && authorizationService.canAccessAssignmentDetails(user, file.getComment().getAssignment())) {
+            && file.getComment().getAssignment() != null
+            && authorizationService.canAccessAssignmentDetails(
+                user, file.getComment().getAssignment())) {
           return true;
         }
       }
@@ -208,17 +209,14 @@ public class FileController {
   }
 
   private boolean isAdmin(User user) {
-    return user.getRole() != null
-            && "ROLE_ADMIN".equals(user.getRole().getName());
+    return user.getRole() != null && "ROLE_ADMIN".equals(user.getRole().getName());
   }
 
   private boolean isTeacher(User user) {
-    return user.getRole() != null
-            && "ROLE_TEACHER".equals(user.getRole().getName());
+    return user.getRole() != null && "ROLE_TEACHER".equals(user.getRole().getName());
   }
 
   private boolean isStudent(User user) {
-    return user.getRole() != null
-            && "ROLE_STUDENT".equals(user.getRole().getName());
+    return user.getRole() != null && "ROLE_STUDENT".equals(user.getRole().getName());
   }
 }

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileController.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileController.java
@@ -172,9 +172,53 @@ public class FileController {
   }
 
   private boolean canAccessFile(User user, FileMetadata file) {
-    // Implement: TEACHER/ADMIN role check OR user is the uploader
-    return user.getId().equals(file.getUploader().getId())
-        || user.getRole().getName().equals("ROLE_ADMIN")
-        || user.getRole().getName().equals("ROLE_TEACHER");
+    // 1. Uploader can always access their own files
+    if (user.getId().equals(file.getUploader().getId())) {
+      return true;
+    }
+
+    // 2. Admin and teachers can access all files
+    if (isAdmin(user) || isTeacher(user)) {
+      return true;
+    }
+
+    // 3. Students can only access files uploaded by teachers/admins (not other students)
+    if (isStudent(user)) {
+      boolean isFromTeacherOrAdmin =
+              "ROLE_TEACHER".equals(file.getUploader().getRole().getName())
+                      || "ROLE_ADMIN".equals(file.getUploader().getRole().getName());
+
+      if (isFromTeacherOrAdmin) {
+        // If file is attached to an assignment
+        if (file.getAssignment() != null
+                && authorizationService.canAccessAssignmentDetails(user, file.getAssignment())) {
+          return true;
+        }
+
+        // If file is attached to a comment
+        if (file.getComment() != null
+                && file.getComment().getAssignment() != null
+                && authorizationService.canAccessAssignmentDetails(user, file.getComment().getAssignment())) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private boolean isAdmin(User user) {
+    return user.getRole() != null
+            && "ROLE_ADMIN".equals(user.getRole().getName());
+  }
+
+  private boolean isTeacher(User user) {
+    return user.getRole() != null
+            && "ROLE_TEACHER".equals(user.getRole().getName());
+  }
+
+  private boolean isStudent(User user) {
+    return user.getRole() != null
+            && "ROLE_STUDENT".equals(user.getRole().getName());
   }
 }

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/LocalFileController.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/LocalFileController.java
@@ -1,17 +1,13 @@
 package org.example.projectbackendteammycodebasebringsalltheboys.controller;
 
-import java.io.IOException;
 import java.io.InputStream;
 import lombok.RequiredArgsConstructor;
 import org.example.projectbackendteammycodebasebringsalltheboys.storage.LocalStorageService;
-import org.example.projectbackendteammycodebasebringsalltheboys.storage.StorageService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
-
-import static org.springframework.web.servlet.function.RequestPredicates.contentType;
 
 @RestController
 @RequestMapping("/api/files/local")
@@ -33,13 +29,12 @@ public class LocalFileController {
 
   @GetMapping("/{s3Key:.+}")
   public ResponseEntity<StreamingResponseBody> downloadFile(@PathVariable String s3Key) {
-    StreamingResponseBody body = out -> {
-      try (InputStream inputStream = storageService.downloadFile(s3Key)) {
-        inputStream.transferTo(out);
-      }
-    };
-    return ResponseEntity.ok()
-            .contentType(MediaType.APPLICATION_OCTET_STREAM)
-            .body(body);
+    StreamingResponseBody body =
+        out -> {
+          try (InputStream inputStream = storageService.downloadFile(s3Key)) {
+            inputStream.transferTo(out);
+          }
+        };
+    return ResponseEntity.ok().contentType(MediaType.APPLICATION_OCTET_STREAM).body(body);
   }
 }

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/LocalFileController.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/LocalFileController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @ConditionalOnProperty(name = "storage.type", havingValue = "local", matchIfMissing = true)
 public class LocalFileController {
 
-  private final StorageService storageService;
+  private final LocalStorageService storageService;
 
   @PutMapping("/{s3Key:.+}")
   public ResponseEntity<Void> uploadFile(
@@ -24,7 +24,7 @@ public class LocalFileController {
       @RequestHeader("Content-Type") String contentType, // available for future validation
       InputStream body) {
 
-    ((LocalStorageService) storageService).saveWithKey(s3Key, body);
+    storageService.saveWithKey(s3Key, body);
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/LocalFileController.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/LocalFileController.java
@@ -1,0 +1,39 @@
+package org.example.projectbackendteammycodebasebringsalltheboys.controller;
+
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.RequiredArgsConstructor;
+import org.example.projectbackendteammycodebasebringsalltheboys.storage.LocalStorageService;
+import org.example.projectbackendteammycodebasebringsalltheboys.storage.StorageService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/files/local")
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "storage.type", havingValue = "local", matchIfMissing = true)
+public class LocalFileController {
+
+  private final StorageService storageService;
+
+  @PutMapping("/{s3Key:.+}")
+  public ResponseEntity<Void> uploadFile(
+      @PathVariable String s3Key,
+      @RequestHeader("Content-Type") String contentType, // available for future validation
+      InputStream body) {
+
+    ((LocalStorageService) storageService).saveWithKey(s3Key, body);
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/{s3Key:.+}")
+  public ResponseEntity<byte[]> downloadFile(@PathVariable String s3Key) throws IOException {
+    try (InputStream is = storageService.downloadFile(s3Key)) {
+      return ResponseEntity.ok()
+          .contentType(MediaType.APPLICATION_OCTET_STREAM)
+          .body(is.readAllBytes());
+    }
+  }
+}

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/LocalFileController.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/LocalFileController.java
@@ -9,6 +9,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import static org.springframework.web.servlet.function.RequestPredicates.contentType;
 
 @RestController
 @RequestMapping("/api/files/local")
@@ -29,11 +32,14 @@ public class LocalFileController {
   }
 
   @GetMapping("/{s3Key:.+}")
-  public ResponseEntity<byte[]> downloadFile(@PathVariable String s3Key) throws IOException {
-    try (InputStream is = storageService.downloadFile(s3Key)) {
-      return ResponseEntity.ok()
-          .contentType(MediaType.APPLICATION_OCTET_STREAM)
-          .body(is.readAllBytes());
-    }
+  public ResponseEntity<StreamingResponseBody> downloadFile(@PathVariable String s3Key) {
+    StreamingResponseBody body = out -> {
+      try (InputStream inputStream = storageService.downloadFile(s3Key)) {
+        inputStream.transferTo(out);
+      }
+    };
+    return ResponseEntity.ok()
+            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .body(body);
   }
 }

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/converter/JsonMapConverter.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/converter/JsonMapConverter.java
@@ -1,0 +1,33 @@
+package org.example.projectbackendteammycodebasebringsalltheboys.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Map;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+@Converter
+public class JsonMapConverter implements AttributeConverter<Map<String, Object>, String> {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public String convertToDatabaseColumn(Map<String, Object> attribute) {
+    try {
+      return attribute == null ? null : objectMapper.writeValueAsString(attribute);
+    } catch (JacksonException e) {
+      throw new RuntimeException("Could not serialize JSON", e);
+    }
+  }
+
+  @Override
+  public Map<String, Object> convertToEntityAttribute(String dbData) {
+    try {
+      if (dbData == null) return null;
+      return objectMapper.readValue(dbData, new TypeReference<>() {});
+    } catch (JacksonException e) {
+      throw new RuntimeException("Could not deserialize JSON", e);
+    }
+  }
+}

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/entity/ActivityLog.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/entity/ActivityLog.java
@@ -8,10 +8,11 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.example.projectbackendteammycodebasebringsalltheboys.converter.JsonMapConverter;
 import org.example.projectbackendteammycodebasebringsalltheboys.enums.ActivityAction;
 import org.example.projectbackendteammycodebasebringsalltheboys.enums.ActivityStatus;
 import org.example.projectbackendteammycodebasebringsalltheboys.enums.EntityType;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "activity_logs")
@@ -40,8 +41,8 @@ public class ActivityLog {
 
   private UUID childId;
 
-  @Convert(converter = JsonMapConverter.class)
-  @Column(columnDefinition = "text")
+  @Column(columnDefinition = "jsonb")
+  @JdbcTypeCode(SqlTypes.JSON)
   private Map<String, Object> details;
 
   @Column(nullable = false)

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/entity/ActivityLog.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/entity/ActivityLog.java
@@ -8,11 +8,10 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.example.projectbackendteammycodebasebringsalltheboys.converter.JsonMapConverter;
 import org.example.projectbackendteammycodebasebringsalltheboys.enums.ActivityAction;
 import org.example.projectbackendteammycodebasebringsalltheboys.enums.ActivityStatus;
 import org.example.projectbackendteammycodebasebringsalltheboys.enums.EntityType;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "activity_logs")
@@ -41,8 +40,8 @@ public class ActivityLog {
 
   private UUID childId;
 
-  @Column(columnDefinition = "jsonb")
-  @JdbcTypeCode(SqlTypes.JSON)
+  @Convert(converter = JsonMapConverter.class)
+  @Column(columnDefinition = "text")
   private Map<String, Object> details;
 
   @Column(nullable = false)

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/mapper/DtoMapper.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/mapper/DtoMapper.java
@@ -16,14 +16,11 @@ import org.example.projectbackendteammycodebasebringsalltheboys.dto.user.Activit
 import org.example.projectbackendteammycodebasebringsalltheboys.dto.user.RoleResponse;
 import org.example.projectbackendteammycodebasebringsalltheboys.dto.user.UserResponse;
 import org.example.projectbackendteammycodebasebringsalltheboys.entity.*;
-import org.example.projectbackendteammycodebasebringsalltheboys.storage.StorageService;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class DtoMapper {
-
-  private final StorageService storageService;
 
   public CaseResponse toCaseResponse(Assignment assignment) {
     if (assignment == null) return null;
@@ -75,8 +72,8 @@ public class DtoMapper {
     response.setFileSize(metadata.getFileSize());
     response.setContentType(metadata.getContentType());
     response.setUploader(toUserResponse(metadata.getUploader()));
-    if (metadata.getS3Key() != null) {
-      response.setDownloadUrl(storageService.generateDownloadUrl(metadata.getS3Key()));
+    if (metadata.getId() != null) {
+      response.setDownloadUrl("/api/files/" + metadata.getId() + "/download");
     }
     return response;
   }

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/storage/LocalStorageService.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/storage/LocalStorageService.java
@@ -65,15 +65,23 @@ public class LocalStorageService implements StorageService {
 
   @Override
   public String generateDownloadUrl(String s3Key) {
-    // For local development, we could return a link to a local controller
-    // or just the file path for now.
-    throw new IllegalStateException(
-        "Local download URL generation requires GET /api/files/download/{s3Key} endpoint.");
+    return "http://localhost:8080/api/files/local/" + s3Key;
   }
 
   @Override
   public String generateUploadUrl(String s3Key, String contentType) {
-    throw new IllegalStateException(
-        "Local upload URL generation requires POST/PUT upload endpoint for local storage.");
+    return "http://localhost:8080/api/files/local/" + s3Key;
+  }
+
+  public void saveWithKey(String s3Key, InputStream inputStream) {
+    try {
+      Path targetPath = this.root.resolve(s3Key).toAbsolutePath().normalize();
+      if (!targetPath.startsWith(this.root)) {
+        throw new IllegalArgumentException("Invalid file key");
+      }
+      Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException e) {
+      throw new RuntimeException("Could not store the file: " + e.getMessage(), e);
+    }
   }
 }

--- a/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/storage/LocalStorageService.java
+++ b/src/main/java/org/example/projectbackendteammycodebasebringsalltheboys/storage/LocalStorageService.java
@@ -65,12 +65,12 @@ public class LocalStorageService implements StorageService {
 
   @Override
   public String generateDownloadUrl(String s3Key) {
-    return "http://localhost:8080/api/files/local/" + s3Key;
+    return "/api/files/local/" + s3Key;
   }
 
   @Override
   public String generateUploadUrl(String s3Key, String contentType) {
-    return "http://localhost:8080/api/files/local/" + s3Key;
+    return "/api/files/local/" + s3Key;
   }
 
   public void saveWithKey(String s3Key, InputStream inputStream) {

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -20,11 +20,11 @@ spring.security.oauth2.client.registration.github.scope=read:user,user:email
 logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.security.oauth2=TRACE
 # AWS S3 configuration (Dummy values for dev)
-# change local to test real s3, remember AWS environment variables
+# change local to s3 to test real s3, remember AWS environment variables
 storage.type=local
-aws.s3.bucket-name=${AWS_S3_BUCKET_NAME}
-aws.s3.access-key=${AWS_ACCESS_KEY_ID}
-aws.s3.secret-key=${AWS_SECRET_ACCESS_KEY}
+aws.s3.bucket-name=${AWS_S3_BUCKET_NAME:dummy}
+aws.s3.access-key=${AWS_ACCESS_KEY_ID:dummy}
+aws.s3.secret-key=${AWS_SECRET_ACCESS_KEY:dummy}
 aws.s3.region=eu-north-1
 
 bootstrap.admin.username=testadmin

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -20,8 +20,13 @@ spring.security.oauth2.client.registration.github.scope=read:user,user:email
 logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.security.oauth2=TRACE
 # AWS S3 configuration (Dummy values for dev)
-aws.s3.bucket-name=my-bucket-name
+# change local to test real s3, remember AWS environment variables
+storage.type=local
+aws.s3.bucket-name=${AWS_S3_BUCKET_NAME}
+aws.s3.access-key=${AWS_ACCESS_KEY_ID}
+aws.s3.secret-key=${AWS_SECRET_ACCESS_KEY}
+aws.s3.region=eu-north-1
+
 bootstrap.admin.username=testadmin
 bootstrap.admin.password=testpassword
 bootstrap.admin.email=testadmin@example.com
-storage.type=local

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -24,3 +24,4 @@ aws.s3.bucket-name=my-bucket-name
 bootstrap.admin.username=testadmin
 bootstrap.admin.password=testpassword
 bootstrap.admin.email=testadmin@example.com
+storage.type=local

--- a/src/test/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileControllerTest.java
+++ b/src/test/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileControllerTest.java
@@ -30,107 +30,110 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles("test")
 class FileControllerTest {
 
-    @Autowired private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-    @MockitoBean private FileService fileService;
-    @MockitoBean private UserService userService;
-    @MockitoBean private CaseService caseService;
-    @MockitoBean private CommentService commentService;
-    @MockitoBean private AuthorizationService authorizationService;
-    @MockitoBean private DtoMapper dtoMapper;
+  @MockitoBean private FileService fileService;
+  @MockitoBean private UserService userService;
+  @MockitoBean private CaseService caseService;
+  @MockitoBean private CommentService commentService;
+  @MockitoBean private AuthorizationService authorizationService;
+  @MockitoBean private DtoMapper dtoMapper;
 
-    private UUID fileId;
-    private FileMetadata fileMetadata;
-    private User uploader;
+  private UUID fileId;
+  private FileMetadata fileMetadata;
+  private User uploader;
 
-    @BeforeEach
-    void setUp() {
-        fileId = UUID.randomUUID();
+  @BeforeEach
+  void setUp() {
+    fileId = UUID.randomUUID();
 
-        Role role = new Role();
-        role.setName("ROLE_STUDENT");
+    Role role = new Role();
+    role.setName("ROLE_STUDENT");
 
-        uploader = new User();
-        uploader.setId(UUID.randomUUID());
-        uploader.setUsername("student");
-        uploader.setRole(role);
+    uploader = new User();
+    uploader.setId(UUID.randomUUID());
+    uploader.setUsername("student");
+    uploader.setRole(role);
 
-        fileMetadata = new FileMetadata();
-        fileMetadata.setId(fileId);
-        fileMetadata.setFileName("test.png");
-        fileMetadata.setContentType("image/png");
-        fileMetadata.setFileSize(1024L);
-        fileMetadata.setS3Key("some-key_test.png");
-        fileMetadata.setUploader(uploader);
-    }
+    fileMetadata = new FileMetadata();
+    fileMetadata.setId(fileId);
+    fileMetadata.setFileName("test.png");
+    fileMetadata.setContentType("image/png");
+    fileMetadata.setFileSize(1024L);
+    fileMetadata.setS3Key("some-key_test.png");
+    fileMetadata.setUploader(uploader);
+  }
 
-    @Test
-    @DisplayName("GET /api/files/{id}/download returns 200 for uploader")
-    @WithMockUser(username = "student", roles = {"STUDENT"})
-    void downloadFile_asUploader_returns200() throws Exception {
-        when(userService.getUserByUsername("student")).thenReturn(Optional.of(uploader));
-        when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
-        when(fileService.downloadFile(fileMetadata))
-                .thenReturn(new ByteArrayInputStream("file content".getBytes()));
+  @Test
+  @DisplayName("GET /api/files/{id}/download returns 200 for uploader")
+  @WithMockUser(
+      username = "student",
+      roles = {"STUDENT"})
+  void downloadFile_asUploader_returns200() throws Exception {
+    when(userService.getUserByUsername("student")).thenReturn(Optional.of(uploader));
+    when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
+    when(fileService.downloadFile(fileMetadata))
+        .thenReturn(new ByteArrayInputStream("file content".getBytes()));
 
-        mockMvc
-                .perform(get("/api/files/" + fileId + "/download"))
-                .andExpect(status().isOk())
-                .andExpect(header().string("Content-Disposition", "attachment; filename=\"test.png\""))
-                .andExpect(content().contentType("image/png"));
-    }
+    mockMvc
+        .perform(get("/api/files/" + fileId + "/download"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Content-Disposition", "attachment; filename=\"test.png\""))
+        .andExpect(content().contentType("image/png"));
+  }
 
-    @Test
-    @DisplayName("GET /api/files/{id}/download returns 404 when file not found")
-    @WithMockUser(username = "student", roles = {"STUDENT"})
-    void downloadFile_fileNotFound_returns404() throws Exception {
-        when(userService.getUserByUsername("student")).thenReturn(Optional.of(uploader));
-        when(fileService.getFileById(any())).thenReturn(Optional.empty());
+  @Test
+  @DisplayName("GET /api/files/{id}/download returns 404 when file not found")
+  @WithMockUser(
+      username = "student",
+      roles = {"STUDENT"})
+  void downloadFile_fileNotFound_returns404() throws Exception {
+    when(userService.getUserByUsername("student")).thenReturn(Optional.of(uploader));
+    when(fileService.getFileById(any())).thenReturn(Optional.empty());
 
-        mockMvc
-                .perform(get("/api/files/" + fileId + "/download"))
-                .andExpect(status().isNotFound());
-    }
+    mockMvc.perform(get("/api/files/" + fileId + "/download")).andExpect(status().isNotFound());
+  }
 
-    @Test
-    @DisplayName("GET /api/files/{id}/download returns 403 when user is not uploader or teacher/admin")
-    @WithMockUser(username = "other", roles = {"STUDENT"})
-    void downloadFile_asOtherStudent_returns403() throws Exception {
-        Role role = new Role();
-        role.setName("ROLE_STUDENT");
+  @Test
+  @DisplayName(
+      "GET /api/files/{id}/download returns 403 when user is not uploader or teacher/admin")
+  @WithMockUser(
+      username = "other",
+      roles = {"STUDENT"})
+  void downloadFile_asOtherStudent_returns403() throws Exception {
+    Role role = new Role();
+    role.setName("ROLE_STUDENT");
 
-        User otherUser = new User();
-        otherUser.setId(UUID.randomUUID());
-        otherUser.setUsername("other");
-        otherUser.setRole(role);
+    User otherUser = new User();
+    otherUser.setId(UUID.randomUUID());
+    otherUser.setUsername("other");
+    otherUser.setRole(role);
 
-        when(userService.getUserByUsername("other")).thenReturn(Optional.of(otherUser));
-        when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
+    when(userService.getUserByUsername("other")).thenReturn(Optional.of(otherUser));
+    when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
 
-        mockMvc
-                .perform(get("/api/files/" + fileId + "/download"))
-                .andExpect(status().isForbidden());
-    }
+    mockMvc.perform(get("/api/files/" + fileId + "/download")).andExpect(status().isForbidden());
+  }
 
-    @Test
-    @DisplayName("GET /api/files/{id}/download returns 200 for teacher")
-    @WithMockUser(username = "teacher", roles = {"TEACHER"})
-    void downloadFile_asTeacher_returns200() throws Exception {
-        Role role = new Role();
-        role.setName("ROLE_TEACHER");
+  @Test
+  @DisplayName("GET /api/files/{id}/download returns 200 for teacher")
+  @WithMockUser(
+      username = "teacher",
+      roles = {"TEACHER"})
+  void downloadFile_asTeacher_returns200() throws Exception {
+    Role role = new Role();
+    role.setName("ROLE_TEACHER");
 
-        User teacher = new User();
-        teacher.setId(UUID.randomUUID());
-        teacher.setUsername("teacher");
-        teacher.setRole(role);
+    User teacher = new User();
+    teacher.setId(UUID.randomUUID());
+    teacher.setUsername("teacher");
+    teacher.setRole(role);
 
-        when(userService.getUserByUsername("teacher")).thenReturn(Optional.of(teacher));
-        when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
-        when(fileService.downloadFile(fileMetadata))
-                .thenReturn(new ByteArrayInputStream("file content".getBytes()));
+    when(userService.getUserByUsername("teacher")).thenReturn(Optional.of(teacher));
+    when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
+    when(fileService.downloadFile(fileMetadata))
+        .thenReturn(new ByteArrayInputStream("file content".getBytes()));
 
-        mockMvc
-                .perform(get("/api/files/" + fileId + "/download"))
-                .andExpect(status().isOk());
-    }
+    mockMvc.perform(get("/api/files/" + fileId + "/download")).andExpect(status().isOk());
+  }
 }

--- a/src/test/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileControllerTest.java
+++ b/src/test/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileControllerTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -78,7 +80,7 @@ class FileControllerTest {
     mockMvc
         .perform(get("/api/files/" + fileId + "/download"))
         .andExpect(status().isOk())
-        .andExpect(header().string("Content-Disposition", "attachment; filename=\"test.png\""))
+        .andExpect(header().exists(HttpHeaders.CONTENT_DISPOSITION))
         .andExpect(content().contentType("image/png"));
   }
 
@@ -135,5 +137,81 @@ class FileControllerTest {
         .thenReturn(new ByteArrayInputStream("file content".getBytes()));
 
     mockMvc.perform(get("/api/files/" + fileId + "/download")).andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("GET /api/files/{id}/download returns 200 with octet-stream for blank contentType")
+  @WithMockUser(
+      username = "student",
+      roles = {"STUDENT"})
+  void downloadFile_blankContentType_returnsOctetStream() throws Exception {
+    fileMetadata.setContentType("");
+
+    when(userService.getUserByUsername("student")).thenReturn(Optional.of(uploader));
+    when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
+    when(fileService.downloadFile(fileMetadata))
+        .thenReturn(new ByteArrayInputStream("file content".getBytes()));
+
+    mockMvc
+        .perform(get("/api/files/" + fileId + "/download"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM));
+  }
+
+  @Test
+  @DisplayName("GET /api/files/{id}/download handles filename with spaces")
+  @WithMockUser(
+      username = "student",
+      roles = {"STUDENT"})
+  void downloadFile_filenameWithSpaces_returns200() throws Exception {
+    fileMetadata.setFileName("my file name.png");
+
+    when(userService.getUserByUsername("student")).thenReturn(Optional.of(uploader));
+    when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
+    when(fileService.downloadFile(fileMetadata))
+        .thenReturn(new ByteArrayInputStream("file content".getBytes()));
+
+    mockMvc
+        .perform(get("/api/files/" + fileId + "/download"))
+        .andExpect(status().isOk())
+        .andExpect(header().exists(HttpHeaders.CONTENT_DISPOSITION));
+  }
+
+  @Test
+  @DisplayName("GET /api/files/{id}/download handles filename with quotes")
+  @WithMockUser(
+      username = "student",
+      roles = {"STUDENT"})
+  void downloadFile_filenameWithQuotes_returns200() throws Exception {
+    fileMetadata.setFileName("file\"name.png");
+
+    when(userService.getUserByUsername("student")).thenReturn(Optional.of(uploader));
+    when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
+    when(fileService.downloadFile(fileMetadata))
+        .thenReturn(new ByteArrayInputStream("file content".getBytes()));
+
+    mockMvc
+        .perform(get("/api/files/" + fileId + "/download"))
+        .andExpect(status().isOk())
+        .andExpect(header().exists(HttpHeaders.CONTENT_DISPOSITION));
+  }
+
+  @Test
+  @DisplayName("GET /api/files/{id}/download handles non-ASCII filename")
+  @WithMockUser(
+      username = "student",
+      roles = {"STUDENT"})
+  void downloadFile_nonAsciiFilename_returns200() throws Exception {
+    fileMetadata.setFileName("ärende_övning.png");
+
+    when(userService.getUserByUsername("student")).thenReturn(Optional.of(uploader));
+    when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
+    when(fileService.downloadFile(fileMetadata))
+        .thenReturn(new ByteArrayInputStream("file content".getBytes()));
+
+    mockMvc
+        .perform(get("/api/files/" + fileId + "/download"))
+        .andExpect(status().isOk())
+        .andExpect(header().exists(HttpHeaders.CONTENT_DISPOSITION));
   }
 }

--- a/src/test/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileControllerTest.java
+++ b/src/test/java/org/example/projectbackendteammycodebasebringsalltheboys/controller/FileControllerTest.java
@@ -1,0 +1,136 @@
+package org.example.projectbackendteammycodebasebringsalltheboys.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.io.ByteArrayInputStream;
+import java.util.Optional;
+import java.util.UUID;
+import org.example.projectbackendteammycodebasebringsalltheboys.entity.FileMetadata;
+import org.example.projectbackendteammycodebasebringsalltheboys.entity.Role;
+import org.example.projectbackendteammycodebasebringsalltheboys.entity.User;
+import org.example.projectbackendteammycodebasebringsalltheboys.mapper.DtoMapper;
+import org.example.projectbackendteammycodebasebringsalltheboys.service.*;
+import org.example.projectbackendteammycodebasebringsalltheboys.testConfig.TestViewConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(FileController.class)
+@Import(TestViewConfig.class)
+@ActiveProfiles("test")
+class FileControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private FileService fileService;
+    @MockitoBean private UserService userService;
+    @MockitoBean private CaseService caseService;
+    @MockitoBean private CommentService commentService;
+    @MockitoBean private AuthorizationService authorizationService;
+    @MockitoBean private DtoMapper dtoMapper;
+
+    private UUID fileId;
+    private FileMetadata fileMetadata;
+    private User uploader;
+
+    @BeforeEach
+    void setUp() {
+        fileId = UUID.randomUUID();
+
+        Role role = new Role();
+        role.setName("ROLE_STUDENT");
+
+        uploader = new User();
+        uploader.setId(UUID.randomUUID());
+        uploader.setUsername("student");
+        uploader.setRole(role);
+
+        fileMetadata = new FileMetadata();
+        fileMetadata.setId(fileId);
+        fileMetadata.setFileName("test.png");
+        fileMetadata.setContentType("image/png");
+        fileMetadata.setFileSize(1024L);
+        fileMetadata.setS3Key("some-key_test.png");
+        fileMetadata.setUploader(uploader);
+    }
+
+    @Test
+    @DisplayName("GET /api/files/{id}/download returns 200 for uploader")
+    @WithMockUser(username = "student", roles = {"STUDENT"})
+    void downloadFile_asUploader_returns200() throws Exception {
+        when(userService.getUserByUsername("student")).thenReturn(Optional.of(uploader));
+        when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
+        when(fileService.downloadFile(fileMetadata))
+                .thenReturn(new ByteArrayInputStream("file content".getBytes()));
+
+        mockMvc
+                .perform(get("/api/files/" + fileId + "/download"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", "attachment; filename=\"test.png\""))
+                .andExpect(content().contentType("image/png"));
+    }
+
+    @Test
+    @DisplayName("GET /api/files/{id}/download returns 404 when file not found")
+    @WithMockUser(username = "student", roles = {"STUDENT"})
+    void downloadFile_fileNotFound_returns404() throws Exception {
+        when(userService.getUserByUsername("student")).thenReturn(Optional.of(uploader));
+        when(fileService.getFileById(any())).thenReturn(Optional.empty());
+
+        mockMvc
+                .perform(get("/api/files/" + fileId + "/download"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /api/files/{id}/download returns 403 when user is not uploader or teacher/admin")
+    @WithMockUser(username = "other", roles = {"STUDENT"})
+    void downloadFile_asOtherStudent_returns403() throws Exception {
+        Role role = new Role();
+        role.setName("ROLE_STUDENT");
+
+        User otherUser = new User();
+        otherUser.setId(UUID.randomUUID());
+        otherUser.setUsername("other");
+        otherUser.setRole(role);
+
+        when(userService.getUserByUsername("other")).thenReturn(Optional.of(otherUser));
+        when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
+
+        mockMvc
+                .perform(get("/api/files/" + fileId + "/download"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("GET /api/files/{id}/download returns 200 for teacher")
+    @WithMockUser(username = "teacher", roles = {"TEACHER"})
+    void downloadFile_asTeacher_returns200() throws Exception {
+        Role role = new Role();
+        role.setName("ROLE_TEACHER");
+
+        User teacher = new User();
+        teacher.setId(UUID.randomUUID());
+        teacher.setUsername("teacher");
+        teacher.setRole(role);
+
+        when(userService.getUserByUsername("teacher")).thenReturn(Optional.of(teacher));
+        when(fileService.getFileById(fileId)).thenReturn(Optional.of(fileMetadata));
+        when(fileService.downloadFile(fileMetadata))
+                .thenReturn(new ByteArrayInputStream("file content".getBytes()));
+
+        mockMvc
+                .perform(get("/api/files/" + fileId + "/download"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/org/example/projectbackendteammycodebasebringsalltheboys/mapper/DtoMapperTest.java
+++ b/src/test/java/org/example/projectbackendteammycodebasebringsalltheboys/mapper/DtoMapperTest.java
@@ -28,7 +28,7 @@ class DtoMapperTest {
 
   @BeforeEach
   void setUp() {
-    dtoMapper = new DtoMapper(storageService);
+    dtoMapper = new DtoMapper();
   }
 
   @Test


### PR DESCRIPTION
implement local storage and fix file upload pipeline

- Add LocalFileController for local dev file handling (PUT/GET)
- Fix LocalStorageService to generate localhost URLs
- Add saveWithKey() to avoid double UUID in filenames
- Fix storage bean conflict (remove @ConditionalOnMissingBean from S3Config)
- Wire storage backend via storage.type property
- Relax file upload permission to allow assigned students (temporary)
- Fix authenticated client for local file PUT requests
- Fix Hibernate 7/Jackson 3 JSON mapping crash in ActivityLog (prod bug)
- Add JsonMapConverter for Map<String, Object> → text serialization

Secure file downloads via backend proxy and add image preview

- Add GET /api/files/{id}/download endpoint that streams file through backend
- Remove presigned download URLs from DtoMapper, use backend URL instead for better security
- Add blob-based download in FileSection to force file download
- Add image preview modal
- Remove StorageService dependency from DtoMapper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app image preview for supported files.
  * New authenticated file download endpoint with streaming.
  * Local file storage endpoints for upload/download.

* **Improvements**
  * More robust download flow with clearer user-facing error messages.
  * Updated role-based access rules for file viewing and downloads.
  * Download URLs normalized to app paths for consistent client behavior.

* **Tests**
  * Added comprehensive controller tests covering download scenarios.

* **Chores**
  * Added JSON handling dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->